### PR TITLE
spike(time): test a particular us timestamp

### DIFF
--- a/axiom/tests/test_time.c
+++ b/axiom/tests/test_time.c
@@ -59,6 +59,9 @@ static void test_parse_unix_time(void) {
   t1 = nr_parse_unix_time("1368811467146000");
   tlib_pass_if_true("parse unix time", 1368811467146000ULL == t1,
                     "t1=" NR_TIME_FMT, t1);
+  t1 = nr_parse_unix_time("1631198283885626");
+  tlib_pass_if_true("parse unix time", 1631198283885626ULL == t1,
+                    "t1=" NR_TIME_FMT, t1);
 
   /*
    * Milliseconds


### PR DESCRIPTION
We encountered some weird issues with microseconds timestamps in `X-Request-Start`.
Just wondering if it could be due to `nr_time` to `double` conversion with big timestamps, so let's run the CI on this case 🤷‍♂️ 